### PR TITLE
Add top1 workaround for improperly specified weight data

### DIFF
--- a/R/ctwas_read_data.R
+++ b/R/ctwas_read_data.R
@@ -277,6 +277,11 @@ read_weight_fusion <- function (weight, chrom, ld_snpinfo, z_snp = NULL, method 
           next
         }
       }
+      # Ensure only top magnitude snp weight in the top1 wgt.matrix column
+      if (g.method == "top1"){
+        wgt.matrix[,"top1"][-which.max(wgt.matrix[,"top1"]^2)] <- 0
+      }
+
       wgt.matrix <- wgt.matrix[abs(wgt.matrix[, g.method]) > 
                                  0, , drop = F]
       wgt.matrix <- wgt.matrix[complete.cases(wgt.matrix), 


### PR DESCRIPTION
top1 fix for multigroup branch